### PR TITLE
Add a script to view books locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Peruse
 This is a simple framework for publishing online books. I originally created it to make it easier to maintain the many online books on my website (amyjko.com), while adding more sophisticated features to support reading.
+
 ## Viewing Books Locally
 
 To build assets and view a book on a local server, you can use the following command (after install dependecies with npm):

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # Peruse
 This is a simple framework for publishing online books. I originally created it to make it easier to maintain the many online books on my website (amyjko.com), while adding more sophisticated features to support reading.
+## Viewing Books Locally
+
+To build assets and view a book on a local server, you can use the following command (after install dependecies with npm):
+
+```language:bash
+$ npm run book -- path/to/book
+```
+
+For example, the following command will open a new browser tab with an example tutorial book:
+
+```language:bash
+$ npm run book -- example/tutorial
+```

--- a/examples/tutorial/book.json
+++ b/examples/tutorial/book.json
@@ -3,7 +3,7 @@
 	"authors": ["[Amy J. Ko|https://faculty.washington.edu/ajko/]"],
 	"cover": "|cover.jpg|A photograph of Boomy the cat sleeping|Boomy is excited that you're trying Peruse!|Amy J. Ko|",
 	"unknown": "|unknown.jpg|A photograph of Boomy the cat looking skeptical.|Boomy is worried that you're lost.|Amy J. Ko|",
-	"description": "This is an example book, intended for presentation with the Peruse framework. Don't let it's simplicity fool you: it demonstrates all of the features of peruse, so you should be able to copy and modify any of its content to hepl you write your book.",
+	"description": "This is an example book, intended for presentation with the Peruse framework. Don't let it's simplicity fool you: it demonstrates all of the features of peruse, so you should be able to copy and modify any of its content to help you write your book.",
 	"chapters": [
 		{
 			"id": "introduction",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1376,6 +1376,15 @@
 			"dev": true,
 			"optional": true
 		},
+		"async": {
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+			"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.17.14"
+			}
+		},
 		"async-each": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
@@ -1475,6 +1484,12 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
 			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+			"dev": true
+		},
+		"basic-auth": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.1.0.tgz",
+			"integrity": "sha1-RSIe5Cn37h5QNb4/UVM/HN/SmIQ=",
 			"dev": true
 		},
 		"binary-extensions": {
@@ -1889,6 +1904,12 @@
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 			"dev": true
 		},
+		"colors": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+			"integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+			"dev": true
+		},
 		"combine-source-map": {
 			"version": "0.8.0",
 			"resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.8.0.tgz",
@@ -1990,6 +2011,12 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
+		},
+		"corser": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+			"integrity": "sha1-jtolLsqrWEDc2XXOuQ2TcMgZ/4c=",
 			"dev": true
 		},
 		"create-ecdh": {
@@ -2206,6 +2233,18 @@
 				"readable-stream": "^2.0.2"
 			}
 		},
+		"ecstatic": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.3.2.tgz",
+			"integrity": "sha512-fLf9l1hnwrHI2xn9mEDT7KIi22UDqA2jaCwyCbSUJh9a1V+LEUSL/JO/6TIz/QyuBURWUHrFL5Kg2TtO1bkkog==",
+			"dev": true,
+			"requires": {
+				"he": "^1.1.1",
+				"mime": "^1.6.0",
+				"minimist": "^1.1.0",
+				"url-join": "^2.0.5"
+			}
+		},
 		"electron-to-chromium": {
 			"version": "1.3.578",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.578.tgz",
@@ -2282,6 +2321,12 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"dev": true
+		},
+		"eventemitter3": {
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+			"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
 			"dev": true
 		},
 		"events": {
@@ -2479,6 +2524,12 @@
 					}
 				}
 			}
+		},
+		"follow-redirects": {
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz",
+			"integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA==",
+			"dev": true
 		},
 		"for-in": {
 			"version": "1.0.2",
@@ -2691,6 +2742,12 @@
 				"minimalistic-assert": "^1.0.1"
 			}
 		},
+		"he": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+			"dev": true
+		},
 		"highlight.js": {
 			"version": "9.18.3",
 			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.3.tgz",
@@ -2733,6 +2790,35 @@
 			"resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
 			"integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E=",
 			"dev": true
+		},
+		"http-proxy": {
+			"version": "1.18.1",
+			"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+			"integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+			"dev": true,
+			"requires": {
+				"eventemitter3": "^4.0.0",
+				"follow-redirects": "^1.0.0",
+				"requires-port": "^1.0.0"
+			}
+		},
+		"http-server": {
+			"version": "0.12.3",
+			"resolved": "https://registry.npmjs.org/http-server/-/http-server-0.12.3.tgz",
+			"integrity": "sha512-be0dKG6pni92bRjq0kvExtj/NrrAd28/8fCXkaI/4piTwQMSDSLMhWyW0NI1V+DBI3aa1HMlQu46/HjVLfmugA==",
+			"dev": true,
+			"requires": {
+				"basic-auth": "^1.0.3",
+				"colors": "^1.4.0",
+				"corser": "^2.0.1",
+				"ecstatic": "^3.3.2",
+				"http-proxy": "^1.18.0",
+				"minimist": "^1.2.5",
+				"opener": "^1.5.1",
+				"portfinder": "^1.0.25",
+				"secure-compare": "3.0.1",
+				"union": "~0.5.0"
+			}
 		},
 		"https-browserify": {
 			"version": "1.0.0",
@@ -3170,6 +3256,12 @@
 				}
 			}
 		},
+		"mime": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+			"dev": true
+		},
 		"mini-create-react-context": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.0.tgz",
@@ -3227,6 +3319,15 @@
 						"is-plain-object": "^2.0.4"
 					}
 				}
+			}
+		},
+		"mkdirp": {
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+			"dev": true,
+			"requires": {
+				"minimist": "^1.2.5"
 			}
 		},
 		"mkdirp-classic": {
@@ -6480,6 +6581,12 @@
 				"wrappy": "1"
 			}
 		},
+		"opener": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+			"integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+			"dev": true
+		},
 		"os-browserify": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
@@ -6579,6 +6686,34 @@
 			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
 			"dev": true
 		},
+		"portfinder": {
+			"version": "1.0.28",
+			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
+			"integrity": "sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==",
+			"dev": true,
+			"requires": {
+				"async": "^2.6.2",
+				"debug": "^3.1.1",
+				"mkdirp": "^0.5.5"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.7",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+					"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+					"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+					"dev": true
+				}
+			}
+		},
 		"posix-character-classes": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -6634,6 +6769,12 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
 			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+			"dev": true
+		},
+		"qs": {
+			"version": "6.9.6",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
+			"integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==",
 			"dev": true
 		},
 		"querystring": {
@@ -6883,6 +7024,12 @@
 			"dev": true,
 			"optional": true
 		},
+		"requires-port": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+			"dev": true
+		},
 		"resolve": {
 			"version": "1.17.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
@@ -6951,6 +7098,12 @@
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"
 			}
+		},
+		"secure-compare": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
+			"integrity": "sha1-8aAymzCLIh+uN7mXTz1XjQypmeM=",
+			"dev": true
 		},
 		"semver": {
 			"version": "5.7.1",
@@ -7599,6 +7752,15 @@
 			"integrity": "sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==",
 			"dev": true
 		},
+		"union": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
+			"integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
+			"dev": true,
+			"requires": {
+				"qs": "^6.4.0"
+			}
+		},
 		"union-value": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -7709,6 +7871,12 @@
 					"dev": true
 				}
 			}
+		},
+		"url-join": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.5.tgz",
+			"integrity": "sha1-WvIvGMBSoACkjXuCxenC4v7tpyg=",
+			"dev": true
 		},
 		"use": {
 			"version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"repository": "https://github.com/amyjko/peruse.git",
 	"scripts": {
 		"clean": "rm build/*",
-		"build-assets": "cp peruse.css build/; cp icons/* build/",
+		"build-assets": "mkdir -p build/; cp peruse.css build/; cp icons/* build/",
 		"build-test": "rm build/*; browserify -g [ babelify --presets [ @babel/preset-env @babel/preset-react ] ] peruse.js | terser > build/peruse.js; npm run build-assets",
 		"test": "npm run clean; npm run build-assets; npm run build-test",
 		"sync": "rsync -avz --delete build/ ajko@ovid.u.washington.edu:~/public_html/peruse/",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"clean": "rm build/*",
 		"build-assets": "cp peruse.css build/; cp icons/* build/",
 		"build-test": "rm build/*; browserify -g [ babelify --presets [ @babel/preset-env @babel/preset-react ] ] peruse.js | terser > build/peruse.js; npm run build-assets",
-		"tutorial": "npm run build-test; rm -r examples/tutorial/build; mkdir -p build/ examples/tutorial/build; cp -r build/ examples/tutorial/build; http-server examples/tutorial -o",
+		"book": "sh scripts/book.sh",
 		"test": "npm run clean; npm run build-assets; npm run build-test",
 		"sync": "rsync -avz --delete build/ ajko@ovid.u.washington.edu:~/public_html/peruse/",
 		"build-prod": "browserify -g uglifyify -t [ babelify --presets [ @babel/preset-env @babel/preset-react ] ] peruse.js | terser --compress --mangle > build/peruse.js",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 		"clean": "rm build/*",
 		"build-assets": "mkdir -p build/; cp peruse.css build/; cp icons/* build/",
 		"build-test": "rm build/*; browserify -g [ babelify --presets [ @babel/preset-env @babel/preset-react ] ] peruse.js | terser > build/peruse.js; npm run build-assets",
+		"tutorial": "npm run build-test; rm -r examples/tutorial/build; mkdir -p build/ examples/tutorial/build; cp -r build/ examples/tutorial/build; http-server examples/tutorial -o",
 		"test": "npm run clean; npm run build-assets; npm run build-test",
 		"sync": "rsync -avz --delete build/ ajko@ovid.u.washington.edu:~/public_html/peruse/",
 		"build-prod": "browserify -g uglifyify -t [ babelify --presets [ @babel/preset-env @babel/preset-react ] ] peruse.js | terser --compress --mangle > build/peruse.js",
@@ -20,6 +21,7 @@
 		"@babel/preset-react": "^7",
 		"babelify": "^10",
 		"browserify": "^16.5.2",
+		"http-server": "^0.12.3",
 		"terser": "^5.3.4",
 		"uglify-js": "^3.11.2",
 		"uglifyify": "^5.0.2"

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
 	"license": "MIT",
 	"repository": "https://github.com/amyjko/peruse.git",
 	"scripts": {
+		"postinstall": "mkdir build/",
 		"clean": "rm build/*",
-		"build-assets": "mkdir -p build/; cp peruse.css build/; cp icons/* build/",
+		"build-assets": "cp peruse.css build/; cp icons/* build/",
 		"build-test": "rm build/*; browserify -g [ babelify --presets [ @babel/preset-env @babel/preset-react ] ] peruse.js | terser > build/peruse.js; npm run build-assets",
 		"tutorial": "npm run build-test; rm -r examples/tutorial/build; mkdir -p build/ examples/tutorial/build; cp -r build/ examples/tutorial/build; http-server examples/tutorial -o",
 		"test": "npm run clean; npm run build-assets; npm run build-test",

--- a/scripts/book.sh
+++ b/scripts/book.sh
@@ -1,0 +1,13 @@
+# Shell script to copy the build directory and 
+# view books on a local server
+
+# Make sure assets are up to date
+npm run build-test
+
+# Copy the build directory to the book's path
+rm -r $1/build
+mkdir -p $1/build
+cp -r build/ $1/build
+
+# Open a new browser tab, proxy to localhost, and disable caching 
+http-server $1 -o -c-1


### PR DESCRIPTION
This PR includes the addition of a small shell script to that opens the a book for local viewing on a server. It does the following, given a path to a book –
* Run `npm run build-test` to compile assets,
* Copy build the build directory to the path of a book so the assets are available locally, 
* Start an HTTP server in a given path and open a browser window.

To test it, clone the repository and run the following commands:
```
$ npm install
$ npm run book -- examples/tutorial
```

This PR also includes creating the build directory in a `postinstall` script which is run automatically by npm after dependencies are installed.

@amyjko – Some info about me / my reasons for contributing: I have been learning a lot from your work as I research for a book I am writing. I've thinking about building something like Peruse for myself, then I encountered it via your website and thought I'd try it out! I had some difficulty viewing the tutorial when I cloned the repo, so here is a PR with my solution in case it is useful to the project. 