### PR TITLE
Fix: Readme example command, remove jquery

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ $ npm run book -- path/to/book
 For example, the following command will open a new browser tab with an example tutorial book:
 
 ```language:bash
-$ npm run book -- example/tutorial
+$ npm run book -- examples/tutorial
 ```

--- a/examples/tutorial/index.html
+++ b/examples/tutorial/index.html
@@ -8,9 +8,6 @@
 		<!-- Bootstrap CSS -->
 		<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" integrity="sha384-JcKb8q3iqJ61gNV9KGb8thSsNjpSL0n8PARn9HuZOnIxN0hoP+VmmDGMN5t9UJ0Z" crossorigin="anonymous">
 
-		<!-- Bootstrap jQuery -->
-		<script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
-
 		<!-- Peruse -->
 		<script src="../../build/peruse.js"></script>
 		<link rel="stylesheet" href="../../build/peruse.css">

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
 	"dependencies": {
 		"ajv": "^6.0",
 		"history": "^4.7.2",
-		"jquery": "^3.0.0",
 		"lodash": "^4.17.10",
 		"npm": "^6.13.4",
 		"react": "^16.3",


### PR DESCRIPTION
Hi Amy! Nice project.

- Noticed the readme example run command fails, this fixes it.
- Noticed jquery is pulled in via npm _and_ html script tag. I assume for Bootstrap. The [Bootstrap docs](https://getbootstrap.com/docs/4.0/getting-started/javascript/) mention that additional modules need to be pulled in when using any of their UI components. [There aren't any additional BS components being pulled in](https://github.com/amyjko/peruse/blob/master/examples/tutorial/index.html#L11), plus I don't see jquery used anywhere else in the examples or app. I ran the example after removing jquery, and the React app worked as expected.